### PR TITLE
Add cron task for autogroups

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -78,3 +78,13 @@ services:
             - %tables.user_notifications%
         tags:
             - { name: notification.type }
+
+    phpbb.autogroups.cron.task.autogroups_check:
+        class: phpbb\autogroups\cron\autogroups_check
+        arguments:
+            - @config
+            - @phpbb.autogroups.manager
+        calls:
+            - [set_name, [cron.task.autogroups_check]]
+        tags:
+            - { name: cron.task }

--- a/cron/autogroups_check.php
+++ b/cron/autogroups_check.php
@@ -66,6 +66,6 @@ class autogroups_check extends \phpbb\cron\task\base
 	 */
 	public function should_run()
 	{
-		return $this->config['autogroups_last_run'] < time() - 86400;
+		return $this->config['autogroups_last_run'] < strtotime('24 hours ago');
 	}
 }

--- a/cron/autogroups_check.php
+++ b/cron/autogroups_check.php
@@ -1,0 +1,71 @@
+<?php
+/**
+*
+* Auto Groups extension for the phpBB Forum Software package.
+*
+* @copyright (c) 2014 phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+*/
+
+namespace phpbb\autogroups\cron;
+
+/**
+ * Auto groups cron task.
+ */
+class autogroups_check extends \phpbb\cron\task\base
+{
+	/** @var \phpbb\config\config */
+	protected $config;
+
+	/** @var \phpbb\autogroups\conditions\manager */
+	protected $manager;
+
+	/**
+	 * Constructor
+	 *
+	 * @param \phpbb\config\config $config                      Config object
+	 * @param \phpbb\autogroups\conditions\manager $manager     Auto groups condition manager object
+	 * @return \phpbb\autogroups\cron\autogroups_check
+	 * @access public
+	 */
+	public function __construct(\phpbb\config\config $config, \phpbb\autogroups\conditions\manager $manager)
+	{
+		$this->config = $config;
+		$this->manager = $manager;
+	}
+
+	/**
+	 * Runs this cron task.
+	 *
+	 * @return null
+	 */
+	public function run()
+	{
+		$this->manager->check_conditions();
+		$this->config->set('autogroups_last_run', time(), false);
+	}
+
+	/**
+	 * Returns whether this cron task can run, given current board configuration.
+	 *
+	 * If warnings are set to never expire, this cron task will not run.
+	 *
+	 * @return bool
+	 */
+	public function is_runnable()
+	{
+		return true;
+	}
+
+	/**
+	 * Returns whether this cron task should run now, because enough time
+	 * has passed since it was last run (24 hours).
+	 *
+	 * @return bool
+	 */
+	public function should_run()
+	{
+		return $this->config['autogroups_last_run'] < time() - 86400;
+	}
+}

--- a/cron/autogroups_check.php
+++ b/cron/autogroups_check.php
@@ -43,7 +43,7 @@ class autogroups_check extends \phpbb\cron\task\base
 	public function run()
 	{
 		$this->manager->check_conditions();
-		$this->config->set('autogroups_last_run', time(), false);
+		$this->config->set('autogroups_last_run', time(), false); // TODO: move this into the check_conditions() method?
 	}
 
 	/**

--- a/migrations/v10x/m5_cron_data.php
+++ b/migrations/v10x/m5_cron_data.php
@@ -1,0 +1,30 @@
+<?php
+/**
+*
+* Auto Groups extension for the phpBB Forum Software package.
+*
+* @copyright (c) 2014 phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+*/
+
+namespace phpbb\autogroups\migrations\v10x;
+
+/**
+* Migration stage 5: Cron data
+*/
+class m5_cron_data extends \phpbb\db\migration\migration
+{
+	/**
+	* Add or update data in the database
+	*
+	* @return array Array of table data
+	* @access public
+	*/
+	public function update_data()
+	{
+		return array(
+			array('config.add', array('autogroups_last_run', 0, true)),
+		);
+	}
+}


### PR DESCRIPTION
I think we can use a single cron task that runs all auto groups. Unless anybody has reasons why each cron based auto group type actually warrants its own cron task.