### PR TITLE
Extract some code duplication into its own method

### DIFF
--- a/conditions/type/base.php
+++ b/conditions/type/base.php
@@ -151,7 +151,7 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 		}
 		else
 		{
-			// Cast user id to integer and pur it inside an array
+			// Cast user id to integer and put it inside an array
 			$user_ids = array((int) $user_ids);
 		}
 

--- a/conditions/type/base.php
+++ b/conditions/type/base.php
@@ -142,6 +142,26 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 	/**
 	 * {@inheritdoc}
 	 */
+	public function prepare_users_for_query($user_ids)
+	{
+		if (is_array($user_ids))
+		{
+			// Cast each array value to integer
+			$user_ids = array_map('intval', $user_ids);
+		}
+		else
+		{
+			// Cast user id to integer and pur it inside an array
+			$user_ids = array((int) $user_ids);
+		}
+
+		return $user_ids;
+	}
+
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function add_users_to_group($user_id_ary, $group_rule_data)
 	{
 		if (!function_exists('group_user_add'))

--- a/conditions/type/membership.php
+++ b/conditions/type/membership.php
@@ -81,7 +81,8 @@ class membership extends \phpbb\autogroups\conditions\type\base
 					'ON' => 'u.user_id = ug.user_id',
 				),
 			),
-			'WHERE' => $this->sql_where_clause($options) . ' AND ' . $this->db->sql_in_set('u.user_type', array(USER_INACTIVE, USER_IGNORE), true),
+			'WHERE' => $this->sql_where_clause($options) . '
+				AND ' . $this->db->sql_in_set('u.user_type', array(USER_INACTIVE, USER_IGNORE), true),
 			'GROUP_BY' => 'u.user_id',
 		);
 

--- a/conditions/type/posts.php
+++ b/conditions/type/posts.php
@@ -75,7 +75,7 @@ class posts extends \phpbb\autogroups\conditions\type\base
 
 		// Is this a sync action? If so, we want to get all users
 		// by setting the $negate arg to true in sql_in_set for 1=1
-		$sync = ($options['action'] == 'sync') ? true : false;
+		$sync = $options['action'] == 'sync';
 
 		// Get data for the users to be checked (exclude bots and guests)
 		$sql = 'SELECT user_id, ' . implode(', ', $condition_data) . '

--- a/conditions/type/posts.php
+++ b/conditions/type/posts.php
@@ -70,17 +70,8 @@ class posts extends \phpbb\autogroups\conditions\type\base
 			'action'	=> '',
 		), $options);
 
-		$user_ids = $options['users'];
-
-		// Clean up array of ids
-		if (is_array($user_ids))
-		{
-			$user_ids = array_map('intval', $user_ids);
-		}
-		else
-		{
-			$user_ids = array((int) $user_ids);
-		}
+		// Prepare the user ids data for use in the query
+		$user_ids = $this->prepare_users_for_query($options['users']);
 
 		// Is this a sync action? If so, we want to get all users
 		// by setting the $negate arg to true in sql_in_set for 1=1

--- a/conditions/type/type_interface.php
+++ b/conditions/type/type_interface.php
@@ -75,6 +75,15 @@ interface type_interface
 	public function get_default_exempt_users();
 
 	/**
+	 * Prepare user ids for querying
+	 *
+	 * @param mixed $user_ids User id(s) expected as int or array
+	 * @return array An array of user id(s)
+	 * @access public
+	 */
+	public function prepare_users_for_query($user_ids);
+
+	/**
 	 * Add user(s) to group
 	 *
 	 * @param array $user_id_ary     User(s) to add to group

--- a/conditions/type/warnings.php
+++ b/conditions/type/warnings.php
@@ -83,7 +83,8 @@ class warnings extends \phpbb\autogroups\conditions\type\base
 					'ON' => 'u.user_id = ug.user_id',
 				),
 			),
-			'WHERE' => $this->sql_where_clause($options) . ' AND ' . $this->db->sql_in_set('u.user_type', array(USER_INACTIVE, USER_IGNORE), true),
+			'WHERE' => $this->sql_where_clause($options) . '
+				AND ' . $this->db->sql_in_set('u.user_type', array(USER_INACTIVE, USER_IGNORE), true),
 			'GROUP_BY' => 'u.user_id',
 		);
 

--- a/tests/conditions/base_test.php
+++ b/tests/conditions/base_test.php
@@ -234,6 +234,34 @@ class base_test extends base
 	}
 
 	/**
+	 * Data for test_prepare_users_for_query
+	 */
+	public function prepare_users_for_query_test_data()
+	{
+		return array(
+			array(1, array(1)),
+			array(array(1, 2), array(1, 2)),
+			array('1', array(1)),
+			array(array(1, '2', 'foobar', '', true, false), array(1, 2, 0, 0, 1, 0)),
+			array('', array(0)),
+			array(array(), array()),
+		);
+	}
+
+	/**
+	 * Test the prepare_users_for_query method
+	 *
+	 * @dataProvider prepare_users_for_query_test_data
+	 */
+	public function test_prepare_users_for_query($user_ids, $expected)
+	{
+		// Instantiate the condition
+		$condition = $this->get_condition();
+
+		$this->assertEquals($expected, $condition->prepare_users_for_query($user_ids));
+	}
+
+	/**
 	 * Test the add_users_to_group method
 	 *
 	 * @dataProvider add_users_to_group_test_data


### PR DESCRIPTION
Moved some duplicated code in each of the auto group classes into its own method. Some classes look like a lot of changes, but it's really just because of removing 1 level of indentation :)