### PR TITLE
Security and Bug fixes

### DIFF
--- a/conditions/type/base.php
+++ b/conditions/type/base.php
@@ -176,15 +176,7 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 		group_user_add($group_id, $user_id_ary);
 
 		// Send notification
-		if ($group_rule_data['autogroups_notify'])
-		{
-			$phpbb_notifications = $this->container->get('notification_manager');
-			$phpbb_notifications->add_notifications('phpbb.autogroups.notification.type.group_added', array(
-				'user_ids'		=> $user_id_ary,
-				'group_id'		=> $group_id,
-				'group_name'	=> get_group_name($group_id),
-			));
-		}
+		$this->send_notifications((bool) $group_rule_data['autogroups_notify'], 'group_added', $user_id_ary, $group_id);
 
 		// Set group as default?
 		if ($group_rule_data['autogroups_default'])
@@ -232,15 +224,7 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 		group_user_del($group_id, $user_id_ary);
 
 		// Send notification
-		if (!empty($group_rule_data['autogroups_notify']))
-		{
-			$phpbb_notifications = $this->container->get('notification_manager');
-			$phpbb_notifications->add_notifications('phpbb.autogroups.notification.type.group_removed', array(
-				'user_ids'		=> $user_id_ary,
-				'group_id'		=> $group_id,
-				'group_name'	=> get_group_name($group_id),
-			));
-		}
+		$this->send_notifications((bool) $group_rule_data['autogroups_notify'], 'group_removed', $user_id_ary, $group_id);
 	}
 
 	/**
@@ -351,5 +335,26 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 		}
 
 		return $user_id_ary;
+	}
+
+	/**
+	 * Send out notifications
+	 *
+	 * @param bool $notify       Should a notification be sent
+	 * @param string $type       Type of notification to send (group_added|group_removed)
+	 * @param array $user_id_ary Array of user(s) to notify
+	 * @param int $group_id      The usergroup identifier
+	 */
+	protected function send_notifications($notify, $type, $user_id_ary, $group_id)
+	{
+		if ($notify)
+		{
+			$phpbb_notifications = $this->container->get('notification_manager');
+			$phpbb_notifications->add_notifications("phpbb.autogroups.notification.type.$type", array(
+				'user_ids'		=> $user_id_ary,
+				'group_id'		=> $group_id,
+				'group_name'	=> get_group_name($group_id),
+			));
+		}
 	}
 }

--- a/conditions/type/base.php
+++ b/conditions/type/base.php
@@ -182,10 +182,7 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 		if ($group_rule_data['autogroups_default'])
 		{
 			// Make sure user_id_ary is an array
-			if (!is_array($user_id_ary))
-			{
-				$user_id_ary = array((int) $user_id_ary);
-			}
+			$user_id_ary = $this->prepare_users_for_query($user_id_ary);
 
 			// Get array of users exempt from default group switching
 			$default_exempt_users = $this->get_default_exempt_users();

--- a/conditions/type/base.php
+++ b/conditions/type/base.php
@@ -123,10 +123,10 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 	{
 		$user_id_ary = array();
 
-		// Get default exempt groups from db or an empty array
-		$group_id_ary = (!$this->config['autogroups_default_exempt']) ? array() : unserialize(trim($this->config['autogroups_default_exempt']));
+		// Get default exempt groups from db
+		$group_id_ary = unserialize(trim($this->config['autogroups_default_exempt']));
 
-		if (!sizeof($group_id_ary))
+		if (empty($group_id_ary))
 		{
 			return $user_id_ary;
 		}
@@ -319,7 +319,7 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 					'users' => $user_id_ary,
 				));
 				// Filter users out users that satisfy other conditions for this group
-				$user_id_ary = array_filter($user_id_ary, function ($user_id) use ($condition, $condition_user_data, $group_rule) {
+				$user_id_ary = array_filter($user_id_ary, function($user_id) use ($condition, $condition_user_data, $group_rule) {
 					return !$condition->check_user($condition_user_data[$user_id][$condition->get_condition_field()], $group_rule);
 				});
 			}
@@ -329,7 +329,7 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 	}
 
 	/**
-	 * Send out notifications
+	 * Send notifications
 	 *
 	 * @param bool $notify       Should a notification be sent
 	 * @param string $type       Type of notification to send (group_added|group_removed)

--- a/conditions/type/base.php
+++ b/conditions/type/base.php
@@ -240,7 +240,7 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 				foreach ($user_row as $user_id => $user_data)
 				{
 					// Check if a user's data is within the min/max range
-					if ($this->check_user($user_data[$this->get_condition_field()], $group_rule))
+					if ($this->check_user_data($user_data[$this->get_condition_field()], $group_rule))
 					{
 						// Check if a user is already a member of checked group
 						if (!in_array($group_rule['autogroups_group_id'], $user_groups[$user_id]))
@@ -283,7 +283,7 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 	 * @return bool True if the user meets the condition, false otherwise
 	 * @access protected
 	 */
-	protected function check_user($value, $group_rule)
+	protected function check_user_data($value, $group_rule)
 	{
 		return ($value >= $group_rule['autogroups_min_value']) &&
 			(empty($group_rule['autogroups_max_value']) || ($value <= $group_rule['autogroups_max_value'])
@@ -320,7 +320,7 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 				));
 				// Filter users out users that satisfy other conditions for this group
 				$user_id_ary = array_filter($user_id_ary, function($user_id) use ($condition, $condition_user_data, $group_rule) {
-					return !$condition->check_user($condition_user_data[$user_id][$condition->get_condition_field()], $group_rule);
+					return !$condition->check_user_data($condition_user_data[$user_id][$condition->get_condition_field()], $group_rule);
 				});
 			}
 		}

--- a/conditions/type/base.php
+++ b/conditions/type/base.php
@@ -67,6 +67,11 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 
 		$this->phpbb_root_path = $phpbb_root_path;
 		$this->php_ext = $php_ext;
+
+		if (!function_exists('group_user_add'))
+		{
+			include($this->phpbb_root_path . 'includes/functions_user.' . $this->php_ext);
+		}
 	}
 
 	/**
@@ -158,17 +163,11 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 		return $user_ids;
 	}
 
-
 	/**
 	 * {@inheritdoc}
 	 */
 	public function add_users_to_group($user_id_ary, $group_rule_data)
 	{
-		if (!function_exists('group_user_add'))
-		{
-			include($this->phpbb_root_path . 'includes/functions_user.' . $this->php_ext);
-		}
-
 		// Set this variable for readability in the code below
 		$group_id = $group_rule_data['autogroups_group_id'];
 
@@ -207,11 +206,6 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 		if (!sizeof($user_id_ary))
 		{
 			return;
-		}
-
-		if (!function_exists('group_user_del'))
-		{
-			include($this->phpbb_root_path . 'includes/functions_user.' . $this->php_ext);
 		}
 
 		// Set this variable for readability in the code below
@@ -341,6 +335,8 @@ abstract class base implements \phpbb\autogroups\conditions\type\type_interface
 	 * @param string $type       Type of notification to send (group_added|group_removed)
 	 * @param array $user_id_ary Array of user(s) to notify
 	 * @param int $group_id      The usergroup identifier
+	 * @return null
+	 * @access protected
 	 */
 	protected function send_notifications($notify, $type, $user_id_ary, $group_id)
 	{

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -90,9 +90,9 @@ class admin_controller implements admin_interface
 				'S_DEFAULT'	=> $row['autogroups_default'],
 				'S_NOTIFY'	=> $row['autogroups_notify'],
 
-				'U_DELETE'	=> "{$this->u_action}&amp;action=delete&amp;autogroups_id=" . $row['autogroups_id'],
-				'U_SYNC'	=> "{$this->u_action}&amp;action=sync&amp;autogroups_id=" . $row['autogroups_id'],
 				'U_EDIT'	=> "{$this->u_action}&amp;action=edit&amp;autogroups_id=" . $row['autogroups_id'],
+				'U_DELETE'	=> "{$this->u_action}&amp;action=delete&amp;autogroups_id=" . $row['autogroups_id'],
+				'U_SYNC'	=> "{$this->u_action}&amp;action=sync&amp;autogroups_id=" . $row['autogroups_id'] . '&amp;hash=' . generate_link_hash('sync' . $row['autogroups_id']),
 			));
 		}
 
@@ -166,6 +166,12 @@ class admin_controller implements admin_interface
 	*/
 	public function resync_autogroup_rule($autogroups_id)
 	{
+		// If the link hash is invalid, stop and show an error message to the user
+		if (!check_link_hash($this->request->variable('hash', ''), 'sync' . $autogroups_id))
+		{
+			trigger_error($this->user->lang('FORM_INVALID') . adm_back_link($this->u_action), E_USER_WARNING);
+		}
+
 		try
 		{
 			$this->manager->sync_autogroups($autogroups_id);

--- a/tests/conditions/base_test.php
+++ b/tests/conditions/base_test.php
@@ -43,6 +43,7 @@ class base_test extends base
 						'autogroups_group_id'	=> 2,
 						'autogroups_default'	=> 1,
 						'autogroups_notify'		=> 0,
+						'autogroups_type_name'	=> 'phpbb.autogroups.type.posts',
 					),
 					array(
 						'autogroups_id' 		=> 2,
@@ -52,6 +53,7 @@ class base_test extends base
 						'autogroups_group_id'	=> 3,
 						'autogroups_default'	=> 1,
 						'autogroups_notify'		=> 0,
+						'autogroups_type_name'	=> 'phpbb.autogroups.type.posts',
 					),
 					array(
 						'autogroups_id' 		=> 3,
@@ -61,6 +63,7 @@ class base_test extends base
 						'autogroups_group_id'	=> 4,
 						'autogroups_default'	=> 0,
 						'autogroups_notify'		=> 0,
+						'autogroups_type_name'	=> 'phpbb.autogroups.type.posts',
 					),
 				),
 			),

--- a/tests/conditions/fixtures/phpbb.autogroups.type.posts.xml
+++ b/tests/conditions/fixtures/phpbb.autogroups.type.posts.xml
@@ -43,10 +43,6 @@
 			<value>1</value>
 			<value>phpbb.autogroups.type.posts</value>
 		</row>
-		<row>
-			<value>2</value>
-			<value>phpbb.autogroups.type.warnings</value>
-		</row>
 	</table>
 	<table name="phpbb_user_group">
 		<column>user_id</column>


### PR DESCRIPTION
Added a link hash to the resync button

Also had to find a way to prevent un-neccessary user removal/re-addition in cases where multiple types of conditions may be set for a single group, and a user may qualify for that group based on 1 auto group rule, but not another, which would have led to that user being constantly removed and re-added to the group. This should fix that.