### PR TITLE
Remove extra sql_escape

### DIFF
--- a/conditions/manager.php
+++ b/conditions/manager.php
@@ -108,8 +108,9 @@ class manager
 	public function add_autogroups_type($autogroups_type_name)
 	{
 		// Insert the type name into the database
-		$sql = 'INSERT INTO ' . $this->autogroups_types_table . '
-			' . $this->db->sql_build_array('INSERT', array('autogroups_type_name' => $this->db->sql_escape($autogroups_type_name)));
+		$sql = 'INSERT INTO ' . $this->autogroups_types_table . ' ' . $this->db->sql_build_array('INSERT', array(
+			'autogroups_type_name' => (string) $autogroups_type_name)
+		);
 		$this->db->sql_query($sql);
 
 		// Return the id of the newly inserted condition type

--- a/conditions/manager.php
+++ b/conditions/manager.php
@@ -108,8 +108,10 @@ class manager
 	public function add_autogroups_type($autogroups_type_name)
 	{
 		// Insert the type name into the database
-		$sql = 'INSERT INTO ' . $this->autogroups_types_table . ' ' . $this->db->sql_build_array('INSERT', array(
-			'autogroups_type_name' => (string) $autogroups_type_name)
+		$sql = 'INSERT INTO ' . $this->autogroups_types_table . ' ' .
+			$this->db->sql_build_array('INSERT', array(
+				'autogroups_type_name' => (string) $autogroups_type_name
+			)
 		);
 		$this->db->sql_query($sql);
 


### PR DESCRIPTION
We shouldn't need the sql_escape used here since the value is already being sql_escaped inside the sql_build_array function.