### PR TITLE
Correctly calculate user age

### DIFF
--- a/conditions/type/birthdays.php
+++ b/conditions/type/birthdays.php
@@ -111,7 +111,7 @@ class birthdays extends \phpbb\autogroups\conditions\type\base
 		$birthday_year = (int) substr($user_birthday, -4);
 		if ($birthday_year)
 		{
-			$birthday_datetime = new \DateTime($user_birthday);
+			$birthday_datetime = new \DateTime(str_replace(' ', '', $user_birthday));
 			$diff = $birthday_datetime->diff($now);
 			$age = (int) $diff->format('%y');
 		}

--- a/conditions/type/birthdays.php
+++ b/conditions/type/birthdays.php
@@ -108,7 +108,8 @@ class birthdays extends \phpbb\autogroups\conditions\type\base
 
 		$age = 0;
 
-		if ($user_birthday)
+		$birthday_year = (int) substr($user_birthday, -4);
+		if ($birthday_year)
 		{
 			$birthday_datetime = new \DateTime($user_birthday);
 			$diff = $birthday_datetime->diff($now);

--- a/conditions/type/birthdays.php
+++ b/conditions/type/birthdays.php
@@ -107,10 +107,27 @@ class birthdays extends \phpbb\autogroups\conditions\type\base
 			$now = phpbb_gmgetdate();
 		}
 
-		// Get birth year from the stored birth date
-		$birthday_year = (int) substr($user_birthday, -4);
+		$age = 0;
 
-		// Return the users age
-		return $birthday_year ? (int) max(0, $now['year'] - $birthday_year) : 0;
+		if ($user_birthday)
+		{
+			list($bday_day, $bday_month, $bday_year) = array_map('intval', explode('-', $user_birthday));
+
+			if ($bday_year)
+			{
+				$diff = $now['mon'] - $bday_month;
+				if ($diff == 0)
+				{
+					$diff = ($now['mday'] - $bday_day < 0) ? 1 : 0;
+				}
+				else
+				{
+					$diff = ($diff < 0) ? 1 : 0;
+				}
+				$age = max(0, (int) ($now['year'] - $bday_year - $diff));
+			}
+		}
+
+		return $age;
 	}
 }

--- a/conditions/type/birthdays.php
+++ b/conditions/type/birthdays.php
@@ -103,29 +103,16 @@ class birthdays extends \phpbb\autogroups\conditions\type\base
 
 		if (!isset($now))
 		{
-			// Get the current UTC timestamp
-			$now = phpbb_gmgetdate();
+			$now = new \DateTime('now');
 		}
 
 		$age = 0;
 
 		if ($user_birthday)
 		{
-			list($bday_day, $bday_month, $bday_year) = array_map('intval', explode('-', $user_birthday));
-
-			if ($bday_year)
-			{
-				$diff = $now['mon'] - $bday_month;
-				if ($diff == 0)
-				{
-					$diff = ($now['mday'] - $bday_day < 0) ? 1 : 0;
-				}
-				else
-				{
-					$diff = ($diff < 0) ? 1 : 0;
-				}
-				$age = max(0, (int) ($now['year'] - $bday_year - $diff));
-			}
+			$birthday_datetime = new \DateTime($user_birthday);
+			$diff = $birthday_datetime->diff($now);
+			$age = (int) $diff->format('%y');
 		}
 
 		return $age;

--- a/tests/conditions/birthdays_test.php
+++ b/tests/conditions/birthdays_test.php
@@ -40,7 +40,7 @@ class birthdays_test extends type_test_case
 	 * User 2 is already a member of groups 1 and 2 (2 is default)
 	 * User 3 is already a member of group 5 (5 is default and exempt)
 	 *
-	 * @return Array of test data
+	 * @return array Array of test data
 	 */
 	public function check_condition_test_data()
 	{


### PR DESCRIPTION
News years day bug. All user's ages go up on Jan 1, since the month and day of birthdays were not being considered.

https://www.phpbb.com/community/app.php/db/extension/auto_groups/support/topic/168756