### PR TITLE
Check membership after user registration

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -55,6 +55,9 @@ class listener implements EventSubscriberInterface
 
 			// Auto Gorups "Last Visit" listeners
 			'core.session_create_after'	=> 'last_visit_check',
+
+			// Auto Groups "Membership" listeners
+			'core.user_add_after'		=> 'membership_check',
 		);
 	}
 
@@ -155,6 +158,20 @@ class listener implements EventSubscriberInterface
 	{
 		$this->manager->check_condition('phpbb.autogroups.type.lastvisit', array(
 			'users'		=> $event['session_data']['session_user_id'],
+		));
+	}
+
+	/**
+	 * Check membership after user registration
+	 *
+	 * @param \phpbb\event\data $event The event object
+	 * @return void
+	 * @access public
+	 */
+	public function membership_check($event)
+	{
+		$this->manager->check_condition('phpbb.autogroups.type.membership', array(
+			'users'		=> $event['user_id'],
 		));
 	}
 }

--- a/tests/event/listener_test.php
+++ b/tests/event/listener_test.php
@@ -54,6 +54,7 @@ class listener_test extends \phpbb_test_case
 			'core.mcp_warn_post_after',
 			'core.mcp_warn_user_after',
 			'core.session_create_after',
+			'core.user_add_after',
 		), array_keys(\phpbb\autogroups\event\listener::getSubscribedEvents()));
 	}
 
@@ -206,6 +207,14 @@ class listener_test extends \phpbb_test_case
 				'session_data',
 				array('session_user_id' => '$user_id'),
 				array('users' => '$user_id'),
+			),
+			array(
+				'phpbb.autogroups.type.membership',
+				'membership_check',
+				'core.user_add_after',
+				'user_id',
+				array('user_id' => 100),
+				array('users' => array('user_id' => 100)),
 			),
 		);
 	}

--- a/tests/functional/membership_test.php
+++ b/tests/functional/membership_test.php
@@ -92,11 +92,12 @@ class membership_test extends autogroups_base
 	 */
 	protected function disable_captcha()
 	{
-		$sql = "UPDATE phpbb_config
-			SET config_value = 0 
-			WHERE config_name = 'enable_confirm'";
-		$this->db->sql_query($sql);
-		$this->purge_cache();
+		$crawler = self::request('GET', "adm/index.php?i=acp_board&mode=registration&sid={$this->sid}");
+		$form = $crawler->selectButton('Submit')->form();
+		$form['config[enable_confirm]']->setValue('0');
+		$crawler = self::submit($form);
+
+		$this->assertContainsLang('CONFIG_UPDATED', $crawler->filter('#main .successbox')->text());
 	}
 
 	/**


### PR DESCRIPTION
With this PR, the `Membership days` condition is checked right after the user registration is completed. Rather than having to wait for the next cron to be triggered, this allows the user to be added to the group immediately if the minimum value is `0`.